### PR TITLE
Make custom left view work in FloatingNotificationBanner

### DIFF
--- a/NotificationBanner/Classes/FloatingNotificationBanner.swift
+++ b/NotificationBanner/Classes/FloatingNotificationBanner.swift
@@ -33,9 +33,10 @@ open class FloatingNotificationBanner: GrowingNotificationBanner {
                 rightView: UIView? = nil,
                 style: BannerStyle = .info,
                 colors: BannerColorsProtocol? = nil,
-                iconPosition: IconPosition = .center) {
+                iconPosition: IconPosition = .center,
+                sideViewSize: CGFloat = 24.0) {
 
-        super.init(title: title, subtitle: subtitle, leftView: leftView, rightView: rightView, style: style, colors: colors, iconPosition: iconPosition)
+        super.init(title: title, subtitle: subtitle, leftView: leftView, rightView: rightView, style: style, colors: colors, iconPosition: iconPosition, sideViewSize: sideViewSize)
         
         if let titleFont = titleFont {
             self.titleFont = titleFont


### PR DESCRIPTION
Current bug:
Custom left/right views in FloatingNotificationBanner are squashed down to 24px, resulting in ugly UI.
This works great if you use it's superclass, GrowingNotificationBanner, though, because it's init exposes a sideViewSize parameter.

Fix:
exposed sideViewSize in the subclass init, passing it to the superview